### PR TITLE
Fix for names with space

### DIFF
--- a/GoogleAuthenticator.php
+++ b/GoogleAuthenticator.php
@@ -74,7 +74,7 @@ class PHPGangsta_GoogleAuthenticator
      * @return string
      */
     public function getQRCodeGoogleUrl($name, $secret) {
-        $urlencoded = urlencode('otpauth://totp/'.$name.'?secret='.$secret.'');
+        $urlencoded = urlencode('otpauth://totp/'.rawurlencode($name).'?secret='.$secret.'');
         return 'https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl='.$urlencoded.'';
     }
 


### PR DESCRIPTION
Atleast with iPhone, I ran into an issue where space causes error.
As a fix, name will will be encoded so instead having "User Name" it will be "User%20Name".
